### PR TITLE
Add command to run a directory of tests

### DIFF
--- a/phpunit.py
+++ b/phpunit.py
@@ -11,12 +11,14 @@ class PhpunitTestCommand(sublime_plugin.WindowCommand):
         file_name = self.window.active_view().file_name()
         phpunit_config_path = self.find_phpunit_config(file_name)
 
+        directory = os.path.dirname(os.path.realpath(file_name))
+
         file_name = file_name.replace(' ', '\ ')
         phpunit_config_path = phpunit_config_path.replace(' ', '\ ')
 
         active_view = self.window.active_view()
 
-        return file_name, phpunit_config_path, active_view
+        return file_name, phpunit_config_path, active_view, directory
 
     def get_current_function(self, view):
         sel = view.sel()[0]
@@ -47,7 +49,7 @@ class PhpunitTestCommand(sublime_plugin.WindowCommand):
 class RunPhpunitTestCommand(PhpunitTestCommand):
 
     def run(self, *args, **kwargs):
-        file_name, phpunit_config_path, active_view = self.get_paths()
+        file_name, phpunit_config_path, active_view, directory = self.get_paths()
 
         self.run_in_terminal('cd ' + phpunit_config_path + ' && phpunit ' + file_name)
 
@@ -55,11 +57,18 @@ class RunPhpunitTestCommand(PhpunitTestCommand):
 class RunSinglePhpunitTestCommand(PhpunitTestCommand):
 
     def run(self, *args, **kwargs):
-        file_name, phpunit_config_path, active_view = self.get_paths()
+        file_name, phpunit_config_path, active_view, directory = self.get_paths()
 
         current_function = self.get_current_function(active_view)
 
         self.run_in_terminal('cd ' + phpunit_config_path + ' && phpunit ' + file_name + ' --filter ' + current_function)
+
+class RunPhpunitTestsInDirCommand(PhpunitTestCommand):
+
+    def run(self, *args, **kwargs):
+        file_name, phpunit_config_path, active_view, directory = self.get_paths()
+
+        self.run_in_terminal('cd ' + phpunit_config_path + ' && phpunit ' + directory)
 
 class FindMatchingTestCommand(sublime_plugin.WindowCommand):
 


### PR DESCRIPTION
This PR adds the ability to run all of the tests in the directory of the current file. You can assign it to a shortcut with this key command:

`{ "keys": ["super+shift+t"], "command": "run_phpunit_tests_in_dir"},`
