### PR TITLE
Added a settings key to specify the path of the phpunit binary file.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,3 +14,5 @@ run_all_phpunit_tests
 ```
 
 By default, this package uses macOS's built-in Terminal.app. If you want to use iTerm, you can do so by setting `"phpunit-sublime-terminal": "iTerm"` in your settings.
+
+If you want to use a different PHPUnit binary file, for example `./vendor/bin/phpunit`, you can do so by setting `"phpunit-binary": "./vendor/bin/phpunit"` in your settings.

--- a/sublime-phpunit.py
+++ b/sublime-phpunit.py
@@ -18,7 +18,10 @@ class PhpunitTestCommand(sublime_plugin.WindowCommand):
 
         active_view = self.window.active_view()
 
-        return file_name, phpunit_config_path, active_view, directory
+        settings = sublime.load_settings("Preferences.sublime-settings")
+        binary = settings.get('phpunit-binary', 'phpunit')
+
+        return file_name, phpunit_config_path, active_view, directory, binary
 
     def get_current_function(self, view):
         sel = view.sel()[0]
@@ -57,33 +60,33 @@ class PhpunitTestCommand(sublime_plugin.WindowCommand):
 class RunPhpunitTestCommand(PhpunitTestCommand):
 
     def run(self, *args, **kwargs):
-        file_name, phpunit_config_path, active_view, directory = self.get_paths()
+        file_name, phpunit_config_path, active_view, directory, binary = self.get_paths()
 
-        self.run_in_terminal('cd ' + phpunit_config_path + ' && phpunit ' + file_name)
+        self.run_in_terminal('cd ' + phpunit_config_path + ' && ' + binary + ' ' + file_name)
 
 class RunAllPhpunitTestsCommand(PhpunitTestCommand):
 
     def run(self, *args, **kwargs):
-        file_name, phpunit_config_path, active_view, directory = self.get_paths()
+        file_name, phpunit_config_path, active_view, directory, binary = self.get_paths()
 
-        self.run_in_terminal('cd ' + phpunit_config_path + ' && phpunit')
+        self.run_in_terminal('cd ' + phpunit_config_path + ' && ' + binary)
 
 
 class RunSinglePhpunitTestCommand(PhpunitTestCommand):
 
     def run(self, *args, **kwargs):
-        file_name, phpunit_config_path, active_view, directory = self.get_paths()
+        file_name, phpunit_config_path, active_view, directory, binary = self.get_paths()
 
         current_function = self.get_current_function(active_view)
 
-        self.run_in_terminal('cd ' + phpunit_config_path + ' && phpunit ' + file_name + ' --filter ' + current_function)
+        self.run_in_terminal('cd ' + phpunit_config_path + ' && ' + binary + ' ' + file_name + ' --filter ' + current_function)
 
 class RunPhpunitTestsInDirCommand(PhpunitTestCommand):
 
     def run(self, *args, **kwargs):
-        file_name, phpunit_config_path, active_view, directory = self.get_paths()
+        file_name, phpunit_config_path, active_view, directory, binary = self.get_paths()
 
-        self.run_in_terminal('cd ' + phpunit_config_path + ' && phpunit ' + directory)
+        self.run_in_terminal('cd ' + phpunit_config_path + ' && ' + binary + ' ' + directory)
 
 class FindMatchingTestCommand(sublime_plugin.WindowCommand):
 


### PR DESCRIPTION
Some times you need to run tests using the phpunit version installed within your application, for example when global composer's autoload.php file conflicts with your application's autoload.php file.

In this way you avoid errors like `Cannot redeclare class/function bla bla bla...`.