### PR TITLE
Use exact pattern matching with phpunit --filter

### DIFF
--- a/sublime-phpunit.py
+++ b/sublime-phpunit.py
@@ -76,7 +76,7 @@ class RunSinglePhpunitTestCommand(PhpunitTestCommand):
 
         current_function = self.get_current_function(active_view)
 
-        self.run_in_terminal('cd ' + phpunit_config_path + ' && phpunit ' + file_name + ' --filter ' + current_function)
+        self.run_in_terminal('cd ' + phpunit_config_path + ' && phpunit ' + file_name + " --filter '/::" + current_function + "$/'")
 
 class RunPhpunitTestsInDirCommand(PhpunitTestCommand):
 


### PR DESCRIPTION
If you have two test methods that start with the same string, both will be executed when running ```phpunit --filter start_of_test_method```. 

E.g.
function it_sets_a_unique_slug()
function is_sets_a_unique_slug_after_a_previous_record_is_deleted()

```phpunit --filter it_sets_a_unique_slug``` will run both of the above tests.

The --filter argument accepts a regex pattern so we can be explicit and make sure only the method that matches the pattern exactly is executed. 

 ```phpunit --filter '/::it_sets_a_unique_slug$/'```
 
This PR applies the above regex to the RunSinglePhpunitTestCommand method so that only the desired test method is run. 