### PR TITLE
Removes any partial commands typed on the terminal

### DIFF
--- a/open_iterm.applescript
+++ b/open_iterm.applescript
@@ -10,7 +10,9 @@ on runTest(_command)
 
 		tell current session of theWindow
 			delay 0.1
-			tell application "System Events" to keystroke "k" using command down
+			tell application "System Events" to keystroke "k" using {command down}
+			tell application "System Events" to keystroke "U" using {control down}
+
 			write text _command
 		end tell
 	end tell


### PR DESCRIPTION
I find myself forgetting to focus Sublime after a test run, pretty often, and starting to write code that ends up being written in my terminal instead of Sublime.

After I switch back to Sublime and resume writing my code, I forget to clear out the terminal and start another test run.

Unfortunately, this causes the test run to fail due to the extra crap left on the command line from the previous run.

This turns into a vicious cycle, because I inevitably hit my test-run hot key again, which generates more command line garbage (because the terminal is focused). Lazy developer problems, I guess, but I finally got tired of pulling my hair out over it.

This fix clears out the command buffer before executing the test command.