### PR TITLE
Re-focus Sublime after running tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,3 +14,32 @@ run_all_phpunit_tests
 ```
 
 By default, this package uses macOS's built-in Terminal.app. If you want to use iTerm, you can do so by setting `"phpunit-sublime-terminal": "iTerm"` in your settings.
+
+#### Options
+
+Below are the options supported by this package. They are set in the user preferences file (`Preferences.sublime-settings -- User`). You can get to these by pressing `⌘` + `,`, or by going to `Sublime > Preferences > Settings`
+
+* * *
+
+
+`phpunit-sublime-terminal` **string** -- *optional* -- **default:** `"Terminal"`
+
+> By default, this package will attempt to open the OS X *Terminal.app* application for executing tests.
+> 
+> If you prefer to use *iTerm.app* set the value for this property to `"iTerm"`.
+
+
+
+`phpunit-sublime-autofocus` **boolean** -- *optional* -- **default:** `false`
+
+> If you want to re-focus sublime after you start your tests, set this to `true`. The package will automatically switch focus back to the last Sublime window you had focused.
+>
+> *Note: This happens pretty much immediately, so if your terminal window is behind your sublime window -- you'll miss all the terminal output. If you activate this, best to make sure your Sublime and Terminal apps aren't stacked.*
+
+
+
+`phpunit-sublime-autofocus-delay` **int** -- *optional* -- **default:** `100`
+
+> The time, in milliseconds, you want to wait before re-focusing Sublime. If `phpunit-sublime-autofocus` is `false`, this option is ignored. This is best used if things are moving too fast for your machine and you need to introduce a delay. Most won't need it.
+>
+>*Note: This delay happens on the main Sublime thread. You **should NOT** try to estimate how long your test suite will run and put that value here. You will end up beach-balling Sublime for the duration of the delay.*

--- a/sublime-phpunit.py
+++ b/sublime-phpunit.py
@@ -5,6 +5,7 @@ import ntpath
 import subprocess
 import sublime
 import sublime_plugin
+from time import sleep
 
 class PhpunitTestCommand(sublime_plugin.WindowCommand):
     def get_paths(self):
@@ -42,17 +43,37 @@ class PhpunitTestCommand(sublime_plugin.WindowCommand):
         settings = sublime.load_settings("Preferences.sublime-settings")
         terminal_setting = settings.get('phpunit-sublime-terminal', 'Terminal')
 
+        autofocus = settings.get('phpunit-sublime-autofocus', False)
+        autofocus_delay = settings.get('phpunit-sublime-autofocus-delay', 250)
+
         osascript_command = 'osascript '
 
         if terminal_setting == 'iTerm':
-            osascript_command += '"' + os.path.dirname(os.path.realpath(__file__)) + '/open_iterm.applescript"'
+            osascript_command += self.path_to('open_iterm.applescript')
             osascript_command += ' "' + command + '"'
         else:
-            osascript_command += '"' + os.path.dirname(os.path.realpath(__file__)) + '/run_command.applescript"'
+            osascript_command += self.path_to('run_command.applescript')
             osascript_command += ' "' + command + '"'
             osascript_command += ' "PHPUnit Tests"'
 
         os.system(osascript_command)
+
+        if (autofocus):
+            self.autofocus_sublime(autofocus_delay)
+
+    def autofocus_sublime(self, delay):
+        if delay > 0:
+            sleep(delay / 1000.0)
+
+        os.system(self.build_autofocus_cmd())
+
+    def build_autofocus_cmd(self):
+        osascript_cmd = 'osascript '
+        osascript_cmd += self.path_to('tab_to_sublime.applescript')
+        return osascript_cmd
+
+    def path_to(self, file):
+        return '"' + os.path.dirname(os.path.realpath(__file__)) + '/' + file + '"'
 
 class RunPhpunitTestCommand(PhpunitTestCommand):
 

--- a/tab_to_sublime.applescript
+++ b/tab_to_sublime.applescript
@@ -1,0 +1,14 @@
+-- This isn't anything fancy, just alt-tabbing to the first
+-- application that is in the alt-tab application list.
+-- it should be sublime text, unless a) something is weird with this system
+-- or b) the user clicked into another application between the time that the tests
+-- started running and the time that this script ran
+
+on tabToSublime()
+	tell application "System Events" to keystroke tab using {command down}
+end tabToSublime
+
+on run
+	tabToSublime()
+end run
+


### PR DESCRIPTION
As I mentioned in #21, I often forget to restore focus to Sublime after running my tests.

This enhancement adds 2 new options (and supporting readme material) for automatically restoring focus to Sublime after tests are run.

By default, autofocus is off. I expect it's fine for most people. But when I have my terminal on one screen and Sublime in the other, it's super handy to have focus automatically be restored. I rarely ever need to type more terminal commands after my test suite starts.