### PR TITLE
Add option to save all files before running tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,3 +14,10 @@ run_all_phpunit_tests
 ```
 
 By default, this package uses macOS's built-in Terminal.app. If you want to use iTerm, you can do so by setting `"phpunit-sublime-terminal": "iTerm"` in your settings.
+
+## Configuration
+
+Key | Description | Type | Default
+----|-------------|------|--------
+`phpunit-sublime-terminal` | Terminal used for running tests. Options: `iTerm` | `string` | macOS Terminal.app
+`phpunit-sublime-save-files` | Save all unsaved files before running tests | `boolean` | `false`

--- a/sublime-phpunit.py
+++ b/sublime-phpunit.py
@@ -41,6 +41,12 @@ class PhpunitTestCommand(sublime_plugin.WindowCommand):
     def run_in_terminal(self, command):
         settings = sublime.load_settings("Preferences.sublime-settings")
         terminal_setting = settings.get('phpunit-sublime-terminal', 'Terminal')
+        save_files = settings.get('phpunit-sublime-save-files')
+
+        if save_files:
+            for view in self.window.views():
+                if view.is_dirty() and view.file_name():
+                    view.run_command('save')
 
         osascript_command = 'osascript '
 


### PR DESCRIPTION
I often run the test command without having saving test file (or some other file) first.  This **optional** value will allow users to have all _unsaved_ files saved before running tests.

As this is an additional configuration option, also started a table of configuration options in the readme.