### PR TITLE
Fix find_phpunit_bin when path contains a space

### DIFF
--- a/sublime-phpunit.py
+++ b/sublime-phpunit.py
@@ -50,7 +50,7 @@ class PhpunitTestCommand(sublime_plugin.WindowCommand):
             if False == found:
                 binpath = os.path.realpath(directory + "/" + path)
 
-                if os.path.isfile(binpath):
+                if os.path.isfile(binpath.replace("\\", "")):
                     found = True
 
         if False == found:


### PR DESCRIPTION
When the path to a project contains a space in the name the python script is unable to locate the locally installed PHPUnit.

This space change removes escape characters from the path before testing if it exists.